### PR TITLE
Fix game crashes when terminal is used

### DIFF
--- a/TarponSimulator2017/TarponGame.cs
+++ b/TarponSimulator2017/TarponGame.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -131,9 +132,13 @@ namespace Tarpon
 		{
 			UniqueInstance.FishDictionnary.Remove (f);
 		}
+			
+		public static void Main() {
+			// Prevent a bug on Linux with Console.WriteLine
+			// Issue can be found here: https://github.com/mono/mono/issues/6752
+			// Can be safely deleted starting from mono 5.12
+			Environment.SetEnvironmentVariable ("TERM","xterm");
 
-		public static void Main ()
-		{
 			var game = new TarponGame ();
 			game.Run ();
 		}


### PR DESCRIPTION
There is a bug when the game is run from the terminal on newest version of Linux due to a new version of ncurse. The bug is already fixed for mono 5.12+ but Fedora still provide only mono 4.8.0 in its repository.

Setting `TERM=xterm` probably force mono to use a fallback, by bypassing ncurses. So it's really a workaround, but it works for us.