### PR TITLE
A camera that follows our boat

### DIFF
--- a/TarponSimulator2017/Draw/Camera/FollowingCamera.cs
+++ b/TarponSimulator2017/Draw/Camera/FollowingCamera.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Tarpon.Core;
+
+namespace Tarpon.Draw
+{
+	public class FollowingCamera
+	{
+		protected GraphicsDeviceManager Graphics;
+		protected GameObject TargetObject;
+
+		public Matrix TransformMatrix {
+			get { 
+				Matrix invert = Matrix.Invert (TargetObject.TotalTransformation);
+				Vector3 scale;
+				Quaternion rotation;
+				Vector3 translation;
+				invert.Decompose (out scale, out rotation, out translation);
+				translation.X += Graphics.PreferredBackBufferWidth / 2;
+				translation.Y += Graphics.PreferredBackBufferHeight / 2;
+				return 
+					Matrix.CreateScale (scale) * 
+					Matrix.CreateFromQuaternion (rotation) *
+					Matrix.CreateTranslation (translation);
+			}
+		}
+
+		public FollowingCamera (GraphicsDeviceManager graphics, GameObject target)
+		{
+			TargetObject = target;
+			Graphics = graphics;
+		}
+	}
+}
+

--- a/TarponSimulator2017/Draw/MapDrawer.cs
+++ b/TarponSimulator2017/Draw/MapDrawer.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Content;
+using Tarpon.Core;
+using System;
 
 namespace Tarpon.Draw
 {
@@ -8,13 +10,13 @@ namespace Tarpon.Draw
 	{
 		Texture2D Texture;
 		Rectangle TextureRegion;
-		int width;
-		int height;
+		GraphicsDeviceManager Graphics;
+		World CoreWorld;
 
-		public MapDrawer (int width, int height)
+		public MapDrawer (GraphicsDeviceManager graphics, World coreWorld)
 		{
-			this.width = width;
-			this.height = height;
+			CoreWorld = coreWorld;
+			Graphics = graphics;
 		}
 
 		public void LoadContent (ContentManager content)
@@ -25,8 +27,12 @@ namespace Tarpon.Draw
 
 		public void Draw (SpriteBatch spriteBatch, GameTime gameTime)
 		{
-			for (int i = 0; i < width; i += 128) {
-				for (int j = 0; j < height; j += 128) {
+			int demiSquareSide = System.Math.Max (Graphics.PreferredBackBufferHeight, Graphics.PreferredBackBufferWidth);
+			float startX = CoreWorld.playerBoat.AbsolutePosition.X - demiSquareSide;
+			float startY = CoreWorld.playerBoat.AbsolutePosition.Y - demiSquareSide;
+
+			for (float i = startX - startX % 128; i < startX+2*demiSquareSide; i += 128) {
+				for (float j = startY - startY % 128; j < startY+2*demiSquareSide; j += 128) {
 					spriteBatch.Draw (
 						Texture,				    // Water PNG 
 						new Vector2 (i, j), 		// Position 

--- a/TarponSimulator2017/TarponGame.cs
+++ b/TarponSimulator2017/TarponGame.cs
@@ -39,6 +39,7 @@ namespace Tarpon
 		List<IDrawer> toDraw;
 		IController toControl;
 		Scene scene;
+		FollowingCamera worldCamera;
 
 		static public int WIDTH;
 		static public int HEIGHT;
@@ -72,9 +73,11 @@ namespace Tarpon
 			toDraw = new List<IDrawer> ();
 			toControl = new MasterController (world, scene);
 
+			worldCamera = new FollowingCamera (graphics, world.playerBoat);
+
 			// Extraction of elements to draw should be done in the "Draw" folder
 			// Note that the order in the list is important => items at the beginning will be drawn fist
-			MapDrawer = new MapDrawer (graphics.PreferredBackBufferWidth, graphics.PreferredBackBufferHeight);
+			MapDrawer = new MapDrawer (graphics, world);
 			toDraw.Add (new BoatDrawer (world.playerBoat));
 			toDraw.Add (new FishingFloatDrawer (world.playerBoat, world.playerBoat.FishingRod.FishingFloat, this.GraphicsDevice));
 			toDraw.Add (new FishingLineDrawer (world.playerBoat, world.playerBoat.FishingRod, this.GraphicsDevice));
@@ -109,7 +112,9 @@ namespace Tarpon
 			base.Draw (gameTime);
 
 			// Start drawing
-			spriteBatch.Begin ();
+			// samplerState is needed, otherwise some lines are drawm between sea tiles
+			// https://gamedev.stackexchange.com/a/25121
+			spriteBatch.Begin (samplerState: SamplerState.PointClamp, transformMatrix: worldCamera.TransformMatrix);
 
 			//Draw elements
 			MapDrawer.Draw (spriteBatch, gameTime);

--- a/TarponSimulator2017/TarponSimulator2017.csproj
+++ b/TarponSimulator2017/TarponSimulator2017.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Core\StateMachine\FishStateMachine\FishStateTriggered.cs" />
     <Compile Include="Core\StateMachine\FishStateMachine\FishStateCaughtTheHook.cs" />
     <Compile Include="Core\StateMachine\RodStateMachine\RodStateHookedTheFish.cs" />
+    <Compile Include="Draw\Camera\FollowingCamera.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Core\" />
@@ -118,5 +119,6 @@
     <Folder Include="Core\StateMachine\" />
     <Folder Include="Core\StateMachine\RodStateMachine\" />
     <Folder Include="Core\StateMachine\FishStateMachine\" />
+    <Folder Include="Draw\Camera\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Close #24 
Finally I didn't use MonoGame extended.

I also had to:
  * Modify how the map is drawn. Now, the map is drawn dynamically and only around the boat on a sufficiently big surface to cover all the screen and preserve performances.
  * Add a spritebatch parameter to prevent lines drawn between sea tiles. Please refer to the stackexchange link if you want to know more.